### PR TITLE
Changes features to be much more flexible and precise.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ traditional silicon CPUs for maximum flexibility.
 * Two IA-64 cores
 * Five SH-4 cores
 * Three AVR32 cores
-* 128 ATTiny85 cores
-* External flash and DDR4L memory
+* One hundred and thirty one ATTiny85 cores
+* External flash and DDR17UL memory
 
 # Hardware details
 
 * GaAsP technology
-* 0.35mm 2104-ball WLCSP package with outer ring of dual row QFN
+* 0.35mm 2131-ball WLCSP package with outer ring of dual row QFN
 * 200W maximum TDP
   * 2000A at 100mV required for VCore
 
 # Interfaces
 
-* PCIe x7 (maximum bus length 3.3mm)
+* PCIe x7 (exact bus length 3.317mm)
 * 6900 baud RS-232
 * ATA-133
 * 1000base-TX PHY on board
@@ -39,12 +39,12 @@ traditional silicon CPUs for maximum flexibility.
     every power input pin pair
 * Clock tree needs 750mV +/- 0.1%
 * -4.2V PLL charge pump supply
-* +30V MEMS gyroscope supply
+* +/-30V MEMS gyroscope supply
 * Ensure laser diode module is cleaned with thioacetone before use
 
 # Reference design
 
-* 38-layer HDI stack-up
+* 39.9-layer HDI stack-up
 * QAM-51 JTAG
 
 # Usage information
@@ -57,13 +57,15 @@ traditional silicon CPUs for maximum flexibility.
 
 * Number of power pins used vs number of cores remaining intact
 * Clock frequency vs black-body spectrum
+* Observable clock frequency vs relative speed to nearest celestial body
 * Voltage supplied vs chip brightness (lumens)
 * Ambient light level vs output bit error rate
 
 # Warnings and errata
 
-* Note: Quantum computer will not work if chip is visible to observer
+* Note: Quantum computer will not work if chip is visible to observer 
+  or known about
 
 # Release date
 
-* Envisioned release date: April 1st, 2020
+* Envisioned release date: March 32nd, 2022


### PR DESCRIPTION
Repackaged the package to be a prime number, allowing for easier desquaring of balls grid.
Relaxes PCI timing requirements.
Fixed an error in the MEMS supply. The voltage is +30V **OR** -30V.
PCB stackup of 39 layers is unrelastic - changed to 39.9 to round down to practically 40.
Performance of relative C is now tracked.
Erratttaa is fixed.
Release date is adjusted to current Mayan Calendar.